### PR TITLE
[FEAT] jwt 로그인 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+resources/application.yml

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,10 @@ dependencies {
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
+	//jwt
+	implementation 'io.jsonwebtoken:jjwt:0.9.1' //자바 jwt 라이브러리
+	implementation 'javax.xml.bind:jaxb-api:2.3.1' //xml 문서와 java 객체 간 매핑을 자동화
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/example/turnpage/domain/member/controller/AuthController.java
+++ b/src/main/java/com/example/turnpage/domain/member/controller/AuthController.java
@@ -1,52 +1,27 @@
 package com.example.turnpage.domain.member.controller;
 
-import com.example.turnpage.domain.member.dto.MemberSignupRequestDto;
+import com.example.turnpage.domain.member.dto.MemberSignupRequest;
 import com.example.turnpage.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @Controller
 public class AuthController {
     private final MemberService memberService;
 
-    @GetMapping("/auth/signup")
-    public String signup() {
-        return "signup";
-    }
-
     @PostMapping("/auth/signup")
-    @ResponseBody
-    public String signup(@RequestParam String username, String password) {
-        MemberSignupRequestDto memberSignupRequestDto = new MemberSignupRequestDto();
-        memberSignupRequestDto.setUsername(username);
-        memberSignupRequestDto.setPassword(password);
+    public @ResponseBody String signup(@RequestBody MemberSignupRequest requestDto) {
 
-        Long memberId = memberService.signup(memberSignupRequestDto);
+        Long memberId = memberService.signup(requestDto);
         return "회원가입에 성공하였습니다. 새로 등록된 회원의 memberId: " + memberId;
     }
 
-    @GetMapping("/auth/login")
-    public String login() {
-        return "login";
-    }
 
     @PostMapping("/auth/login")
-    public @ResponseBody String loginProcess() {
+    public @ResponseBody String login() {
+
         return "hi";
-    }
-
-    @GetMapping("/public")
-    public @ResponseBody String publicAccess() {
-        return "이 페이지는 모든 사용자가 이용할 수 있습니다. 당신은 로그인하지 않았을 것 같네요 :<";
-    }
-
-    @GetMapping("/private")
-    public @ResponseBody String privateAccess() {
-        return "이 페이지는 로그인된 사용자만 이용할 수 있습니다. 당신은 로그인한 상태네요? :>";
     }
 }

--- a/src/main/java/com/example/turnpage/domain/member/dto/MemberLoginRequest.java
+++ b/src/main/java/com/example/turnpage/domain/member/dto/MemberLoginRequest.java
@@ -1,0 +1,15 @@
+package com.example.turnpage.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberLoginRequest {
+    private String username;
+    private String password;
+}

--- a/src/main/java/com/example/turnpage/domain/member/dto/MemberSignupRequest.java
+++ b/src/main/java/com/example/turnpage/domain/member/dto/MemberSignupRequest.java
@@ -1,25 +1,24 @@
 package com.example.turnpage.domain.member.dto;
 
 import com.example.turnpage.domain.member.entity.Member;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import com.example.turnpage.domain.member.entity.Role;
+import lombok.*;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Getter
-@Setter
 @NoArgsConstructor
-public class MemberSignupRequestDto {
+@AllArgsConstructor
+@Builder
+public class MemberSignupRequest {
     private String username;
     private String password;
 
-    public Member toEntity() {
+    public Member toEntity(String password) {
         return Member.builder()
                 .name(username.split("@")[0])
                 .email(username)
                 .password(password)
-                .role("USER")
+                .role(String.valueOf(Role.USER))
                 .inviteCode(RandomStringUtils.random(10, true, true))
                 .build();
     }

--- a/src/main/java/com/example/turnpage/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/turnpage/domain/member/service/MemberService.java
@@ -1,6 +1,6 @@
 package com.example.turnpage.domain.member.service;
 
-import com.example.turnpage.domain.member.dto.MemberSignupRequestDto;
+import com.example.turnpage.domain.member.dto.MemberSignupRequest;
 import com.example.turnpage.domain.member.entity.Member;
 import com.example.turnpage.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -13,14 +13,13 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
 
-    public Long signup(MemberSignupRequestDto memberSignupRequestDto) {
+    public Long signup(MemberSignupRequest memberSignupRequest) {
         // 이메일 중복 확인 코드
         //
 
-        String encodedPassword = passwordEncoder.encode(memberSignupRequestDto.getPassword());
-        memberSignupRequestDto.setPassword(encodedPassword);
+        String encodedPassword = passwordEncoder.encode(memberSignupRequest.getPassword());
 
-        Member member = memberSignupRequestDto.toEntity();
+        Member member = memberSignupRequest.toEntity(encodedPassword);
         Long memberId = memberRepository.save(member).getId();
         return memberId;
     }

--- a/src/main/java/com/example/turnpage/global/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/turnpage/global/config/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,62 @@
+package com.example.turnpage.global.config.jwt;
+
+import com.example.turnpage.domain.member.dto.MemberLoginRequest;
+import com.example.turnpage.domain.member.entity.Member;
+import com.example.turnpage.global.config.security.MemberDetails;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+import java.time.Duration;
+
+@Slf4j(topic = "로그인 및 JWT 생성")
+public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final JwtUtils jwtUtils;
+
+    public JwtAuthenticationFilter(JwtUtils jwtUtils) {
+        this.jwtUtils = jwtUtils;
+        setFilterProcessesUrl("/auth/login"); // 해당 경로로 요청이 들어왔을 때,
+    }
+
+    // 로그인 시, username 과 password 를 바탕으로 UsernamePasswordAuthenticationToken 을 발급
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) {
+        try {
+            //request의 inputstream값을 읽어서 MemberLoginRequestDto 생성
+            MemberLoginRequest requestDto = new ObjectMapper().readValue(request.getInputStream(), MemberLoginRequest.class);
+
+            //authentication 객체를 생성 (UsernamePasswordAuthenticationToken), authenticationManager가 인증을 진행하도록함
+            return getAuthenticationManager().authenticate(
+                    new UsernamePasswordAuthenticationToken(requestDto.getUsername(), requestDto.getPassword(),null)
+            );
+        } catch (IOException e) {
+            log.error(e.getMessage());
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+
+    // 로그인 성공 시
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws ServletException, IOException {
+        Member member = ((MemberDetails) authResult.getPrincipal()).getMember();
+
+        String token = jwtUtils.generateToken(member, Duration.ofMinutes(30)); //토큰 생성
+        response.addHeader(JwtUtils.AUTHORIZATION_HEADER, token);  //생성한 토큰을 헤더에 추카
+
+    }
+
+    // 로그인 실패 시
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) {
+        response.setStatus(401);
+    }
+}

--- a/src/main/java/com/example/turnpage/global/config/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/example/turnpage/global/config/jwt/JwtAuthorizationFilter.java
@@ -1,0 +1,52 @@
+package com.example.turnpage.global.config.jwt;
+
+import com.example.turnpage.global.config.security.MemberDetailsService;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j(topic = "JWT 검증 및 인가")
+@RequiredArgsConstructor
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+    private final JwtUtils jwtUtils;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain filterChain) throws ServletException, IOException {
+
+        String tokenValue = jwtUtils.getJwtFromHeader(req);
+        //가져온 토큰이 유효한지 확인
+        if (StringUtils.hasText(tokenValue)) {
+            if (!jwtUtils.validateToken(tokenValue)) {
+                log.error("Token Error");
+                return;
+            }
+
+            //유효한 토큰일 경우 인증 정보 설정
+            try {
+                SecurityContext context = SecurityContextHolder.createEmptyContext();
+                Authentication authentication = jwtUtils.getAuthentication(tokenValue);
+                context.setAuthentication(authentication);
+
+                SecurityContextHolder.setContext(context);
+
+
+            } catch (Exception e) {
+                log.error(e.getMessage());
+                return;
+            }
+        }
+
+        filterChain.doFilter(req, res);
+    }
+}

--- a/src/main/java/com/example/turnpage/global/config/jwt/JwtUtils.java
+++ b/src/main/java/com/example/turnpage/global/config/jwt/JwtUtils.java
@@ -1,0 +1,98 @@
+package com.example.turnpage.global.config.jwt;
+
+import com.example.turnpage.domain.member.entity.Member;
+import com.example.turnpage.global.config.security.MemberDetails;
+import com.example.turnpage.global.config.security.MemberDetailsService;
+import io.jsonwebtoken.*;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Set;
+
+@Slf4j(topic = "JwtUtil")
+@Component
+@RequiredArgsConstructor
+public class JwtUtils {
+    /* 1. JWT 데이터 준비하기 */
+    public static final String AUTHORIZATION_HEADER = "Authorization";      // Header KEY 값
+    public static final String BEARER_PREFIX = "Bearer ";       // Token 식별자
+    @Value("${jwt.secret_key}")
+    private String jwtSecretKey;
+
+    private final MemberDetailsService memberDetailsService;
+
+    public String generateToken(Member member, Duration expiredAt) {
+        Date now = new Date();
+        return makeToken(new Date(now.getTime() + expiredAt.toMillis()), member);
+    }
+
+    //JWT 토큰 생성
+    private String makeToken(Date expiry, Member member) {
+        Date now = new Date();
+
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE) //typ: JWT
+                //payload값
+                .setIssuedAt(now) // iat: 토큰 발행 시간
+                .setExpiration(expiry) // exp: 만료 시간
+                .setSubject(member.getEmail()) // sub: 유저의 이메일
+                .claim("id", member.getId()) //클레임 id : 유저 id
+                //서명 : 비밀값과 해시값을 HS256 방식으로 암호화
+                .signWith(SignatureAlgorithm.HS256, jwtSecretKey)
+                .compact();
+    }
+
+    //토큰 값 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser().setSigningKey(jwtSecretKey).parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.error("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.");
+        } catch (ExpiredJwtException e) {
+            log.error("Expired JWT token, 만료된 JWT token 입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.error("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.");
+        } catch (IllegalArgumentException e) {
+            log.error("JWT claims is empty, 잘못된 JWT 토큰 입니다.");
+        }
+        return false;
+    }
+
+    //토큰 기반으로 인증 정보를 가져오는 메서드
+    //클레임 정보를 반환 받아 getSubject()를 통해 토큰 제목 sub와 토큰 기반 인증 정보를 생성
+    public Authentication getAuthentication(String token) {
+        String sub = getClaims(token).getSubject();
+
+        MemberDetails memberDetails = memberDetailsService.loadUserByUsername(sub);
+        return new UsernamePasswordAuthenticationToken(
+                memberDetails, token, memberDetails.getAuthorities());
+    }
+
+    //비밀 값으로 복호화 한 다음 클레임 정보 반환
+    private Claims getClaims(String token) {
+        return Jwts.parser()
+                .setSigningKey(jwtSecretKey)
+                .parseClaimsJws(token)
+                .getBody(); //payload에 해당하는 부분의 정보 반환
+    }
+
+    //헤더에서 jwt 토큰 값 받아오기
+    public String getJwtFromHeader(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/turnpage/global/config/security/MemberDetails.java
+++ b/src/main/java/com/example/turnpage/global/config/security/MemberDetails.java
@@ -28,6 +28,9 @@ public class MemberDetails implements UserDetails {
         return member.getPassword();
     }
 
+    public Member getMember() {
+        return member;
+    }
     @Override
     public String getUsername() {
         return member.getEmail();

--- a/src/main/java/com/example/turnpage/global/config/security/MemberDetailsService.java
+++ b/src/main/java/com/example/turnpage/global/config/security/MemberDetailsService.java
@@ -14,7 +14,7 @@ public class MemberDetailsService implements UserDetailsService {
     private final MemberRepository memberRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+    public MemberDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         Member member = memberRepository.findByEmail(username)
                 .orElseThrow(() -> new UsernameNotFoundException("해당 이메일을 가진 회원이 존재하지 않습니다."));
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,9 +1,8 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/turnpage?serverTimezone=Asia/Seoul
-    username: bfly
-    password: 20203085
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/archiveB?serverTimezone=Asia/Seoul
+    username: root
+    password: 1111111111
 
   sql:
     init:
@@ -17,17 +16,8 @@ spring:
 
     hibernate:
       ddl-auto: create-drop
-
-    properties:
-      hibernate:
-        format_sql: true
-        default_batch_fetch_size: 500
-
-  servlet:
-    multipart:
-      max-file-size: 100MB
-      max-request-size: 100MB
-
+jwt:
+  secret_key: springboot-jwt
 
 logging:
   level:
@@ -40,29 +30,3 @@ logging:
 
   pattern:
   dateformat: yyyy-MM-dd HH:mm:ss.SSS, Asia/Seoul
-
-
-cloud:
-  aws:
-    s3:
-      bucket:
-    credentials:
-      access-key:
-      secret-key:
-    region:
-      static: ap-northeast-2
-      auto: false
-    stack:
-      auto: false
-
-
-public-data:
-  book-search:
-    encoding-service-key:
-    decoding-service-key:
-    url:
-
-  bestseller:
-    encoding-service-key:
-    decoding-service-key:
-    url:


### PR DESCRIPTION
## ❗️ 이슈 번호
Closes #7

## 📝 작업 내용
jwtAuthenticationFilter에서 /auth/login으로 오는 로그인 요청을 받아  authenticationManager가 인증을 수행하도록 하고, 로그인이 성공하면 jwt를 발급해준다.
jwtAuthorizationFilter에서는 헤더의 토큰을 확인하여 인증이 필요한 요청을 수행하도록 한다.
## 💭 주의 사항

## 💡 리뷰 포인트
